### PR TITLE
fix confirm unsaved modal on Edit Permission

### DIFF
--- a/app/assets/javascripts/alert_unsaved.js
+++ b/app/assets/javascripts/alert_unsaved.js
@@ -1,47 +1,61 @@
 
-let unsaved = false;
+let $_UNSAVED = false;
  
 $(document).on('change', 'form[role="check-modified"]:not([data-remote]) :input', function() {
-  return unsaved = true;
+  return $_UNSAVED = true;
 });
 
 $(document).on('turbolinks:load', function() {
-  return unsaved = false;
+  return $_UNSAVED = false;
 });
  
 $(document).on('submit', 'form[role="check-modified"]', function() {
-  unsaved = false;
+  $_UNSAVED = false;
 });
+
+$(document).on('change', 'form[role="check-modified"].editing', function() {
+  return $_UNSAVED = true;
+}); 
  
- 
+
 $(document).on('turbolinks:before-visit', function(event) {
   /* check if exists a product unsaved on order products form */
   if($(document).find('.unsaved-row').length){
-    unsaved = true;
+    $_UNSAVED = true;
   };
 
-  if(unsaved){
+  if($_UNSAVED){
     event.preventDefault();
-    modalConfirm(function(confirm){
-      if(confirm){
-        window.location = event.originalEvent.data.url;
-      }
-    });
+    modalConfirm(event.originalEvent.data.url);
   }
 });
 
-// esta funcion abre el modal de confirmacion, al tratar de abandonar una pagina sin haber guardado
-function modalConfirm(callback){
-
+function modalConfirm(target, isModal = false, callback = null){
   $("#confirm-unsaved").modal('show');
-
   $("#confirm-unsaved-btn").on("click", function(){
-    callback(true);
+    toggleLoading();
+    if(isModal){
+      $(target).modal('show');
+      toggleLoading();
+    }else if(callback !== null){
+      callback();
+    }else if(target !== undefined && target !== null){
+      continueTo(target);
+    }
     $("#confirm-unsaved").modal('hide');
+    $_UNSAVED = false;
+    $(this).unbind();
+    $("#no-confirm-unsaved-btn").unbind();
   });
   
   $("#no-confirm-unsaved-btn").on("click", function(){
-    callback(false);
     $("#confirm-unsaved").modal('hide');
+    $(this).unbind();
+    $("#confirm-unsaved-btn").unbind();
   });
+  return;
 };
+
+function continueTo(target){
+  window.location = target;
+}

--- a/app/assets/javascripts/permission.js
+++ b/app/assets/javascripts/permission.js
@@ -1,7 +1,5 @@
 $(document).on('turbolinks:load', function () {
   if (!(_PAGE.controller === 'permissions' && (['new', 'edit', 'create', 'update'].includes(_PAGE.action)))) return false;
-  
-
 
   $('#remote_form_sector_selector').on('changed.bs.select', function (e) {
     toggleLoading();
@@ -11,39 +9,17 @@ $(document).on('turbolinks:load', function () {
   $("#permission_users").on('submit', () => {
     toggleLoading();
   });
-
-  $("#open-sectors-select-modal").on('click', (e) => {
-    const modalId = $(e.target).attr('data-target')
-    if ($("#permission_users").hasClass('editing')) {
-      modalConfirm(function (confirm) {
-        if (confirm) {
-          $(modalId).modal('show');
-        }
-      });
-    } else {
-      $(modalId).modal('show');
-    }
-  })
 });
 
-$(document).on('turbolinks:before-visit', function (event) {
-  event.preventDefault();
-  if ($("#permission_users").hasClass('editing')) {
-    modalConfirm(function (confirm) {
-      if (confirm) {
-        window.location = event.originalEvent.data.url;
-      }else return;
-    });
+function addSectorClick(e){
+  if ($_UNSAVED) {
+    modalConfirm($(e.target).attr('data-target'), true);
   } else {
-    window.location = event.originalEvent.data.url;
+    $($(e.target).attr('data-target')).modal('show');
   }
-  return;
-});
+}
 
 function permissionModChange(e){
-  if (!$(e.target).hasClass('editing')) {
-    $(e.target).closest('form#permission_users').addClass('editing')
-  }
   const parent = $(e.target).closest('.card');
   const permissions = parent.find('.perm-toggle-button');
   permissions.each((index, permission) => {
@@ -53,9 +29,6 @@ function permissionModChange(e){
 }
 
 function permissionChange(e){
-  if (!$(e.target).hasClass('editing')) {
-    $(e.target).closest('form#permission_users').addClass('editing')
-  }
   $(e.target).siblings("input[type='hidden']").val(!$(e.target).is(':checked'));
   // mark "todos" checkbox as checked if all children are checked
   const parentCheckbox = $(e.target).closest('.card').find('input[type=checkbox].perm-mod-toggle-button').first();
@@ -104,16 +77,13 @@ function toggleRole(e) {
 }
 
 function changeSector(change_sector_url) {
-  if ($("#permission_users").hasClass('editing')) {
-    modalConfirm(function (confirm) {
-      if (confirm) {
-        toggleLoading();
-        $.ajax({
-          url: change_sector_url,
-          dataType: 'script',
-          method: 'GET',
-        })
-      }
+  if ($_UNSAVED) {
+    modalConfirm(null, false,function () {
+      $.ajax({
+        url: change_sector_url,
+        dataType: 'script',
+        method: 'GET',
+      });
     });
   } else {
     toggleLoading();
@@ -123,7 +93,6 @@ function changeSector(change_sector_url) {
       method: 'GET',
     })
   }
-
 }
 
 

--- a/app/views/permissions/build_from_request.js.erb
+++ b/app/views/permissions/build_from_request.js.erb
@@ -1,13 +1,12 @@
 <% lotcation_select = escape_javascript(
   render(partial: 'permissions/partials/location_select')
 ) %>
-$("#location_select_container").html("<%= lotcation_select %>");
 
 <% permissions_list = escape_javascript(
   render(partial: 'permissions/partials/list')
 ) %>
+
+$("#location_select_container").html("<%= lotcation_select %>");
 $("#permissions_list").html("<%= permissions_list %>");
-
 $("#permission-request-summary").alert('close');
-
 toggleLoading();

--- a/app/views/permissions/edit.html.erb
+++ b/app/views/permissions/edit.html.erb
@@ -14,7 +14,16 @@
     </div>
   </div>
   <div class="card-body">
-    <%= simple_form_for 'permission_users', url: update_permissions_users_admin_path(@user), remote: true, html: { method: 'PUT', name: 'permission_users',id: 'permission_users', novalidate: true} do |f| %>
+    <%= simple_form_for 'permission_users', 
+                        url: update_permissions_users_admin_path(@user), 
+                        remote: true, 
+                        html: { 
+                          class: 'editing',
+                          method: 'PUT', 
+                          name: 'permission_users',
+                          id: 'permission_users',
+                          role: 'check-modified'
+                        } do |f| %>
       <div class="row">
         <div class="col-3 border-right">
           <div class="d-flex align-items-center justify-content-between">

--- a/app/views/permissions/partials/_location_select.html.erb
+++ b/app/views/permissions/partials/_location_select.html.erb
@@ -1,5 +1,5 @@
 <div>
-  <button type="button" class="btn btn-primary w-100" data-target="#sector-selection" id="open-sectors-select-modal">
+  <button type="button" class="btn btn-primary w-100" data-target="#sector-selection" onclick="addSectorClick(event);">
     Agregar sector <%= fa_icon 'plus' %>
   </button>
   <ul class="mt-3" id ="sectors-list">

--- a/app/views/permissions/permission_change_sector.js.erb
+++ b/app/views/permissions/permission_change_sector.js.erb
@@ -1,22 +1,11 @@
 <% lotcation_select = escape_javascript(
   render(partial: 'permissions/partials/location_select')
 ) %>
-$("#location_select_container").html("<%= lotcation_select %>");
 <% permissions_list = escape_javascript(
   render(partial: 'permissions/partials/list')
 ) %>
+
+$("#location_select_container").html("<%= lotcation_select %>");
 $("#permissions_list").html("<%= permissions_list %>");
-$("#open-sectors-select-modal").on('click', (e) => {
-const modalId = $(e.target).attr('data-target')
-if ($("#permission_users").hasClass('editing')) {
-modalConfirm(function(confirm){
-if(confirm){
-$(modalId).modal('show');
-}
-});
-}else{      
-$(modalId).modal('show');
-}
-})
 toggleLoading();
 

--- a/app/views/permissions/update.js.erb
+++ b/app/views/permissions/update.js.erb
@@ -23,19 +23,5 @@ $("#modules-links").html("<%= header %>");
 $("#edit-title").html("<%= edit_title %>");
 $("#location_select_container").html("<%= lotcation_select %>");
 $("#permissions_list").html("<%= permissions_list %>");
-
-
-  $("#open-sectors-select-modal").on('click', (e) => {
-    const modalId = $(e.target).attr('data-target')
-    if ($("#permission_users").hasClass('editing')) {
-      modalConfirm(function(confirm){
-        if(confirm){
-          $(modalId).modal('show');
-        }
-      });
-    }else{      
-      $(modalId).modal('show');
-    }
-  })
-$("#permission_users").removeClass('editing')
-  toggleLoading();
+$_UNSAVED = false;
+toggleLoading();

--- a/app/views/users/adds_sector.js.erb
+++ b/app/views/users/adds_sector.js.erb
@@ -1,35 +1,14 @@
-<% js_available_sectors = escape_javascript(
-  render(partial: 'permissions/partials/available_sectors')
-) %>
-
-<% js_sector_select = escape_javascript(
-  render(partial: 'permissions/partials/select_sector')
-) %>
-
 <% lotcation_select = escape_javascript(
   render(partial: 'permissions/partials/location_select')
 ) %>
 
-
-$("#location_select_container").html("<%= lotcation_select %>");
-$("#open-sectors-select-modal").on('click', (e) => {
-    const modalId = $(e.target).attr('data-target')
-    if ($("#permission_users").hasClass('editing')) {
-      modalConfirm(function(confirm){
-        if(confirm){
-          $(modalId).modal('show');
-        }
-      });
-    }else{      
-      $(modalId).modal('show');
-    }
-  })
-
 <% permissions_list = escape_javascript(
   render(partial: 'permissions/partials/list')
 ) %>
+
+$("#location_select_container").html("<%= lotcation_select %>");
 $("#permissions_list").html("<%= permissions_list %>");
-$("#permission_users").addClass('editing')
 
 $("#sector-selection").modal('hide');
+$_UNSAVED = true;
 toggleLoading();


### PR DESCRIPTION
Unsaved modal displays on:

Set a role and try to change link
Set a permission and try to change link
Set a new sector and try to change link
Set a new sector and try to change sector editing
Set a new sector twice consecutives time without save before.